### PR TITLE
changed openrc service so that it monitors the timeshift snapshot dir…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install:
 	@install -Dm755 -t "$(DESTDIR)/etc/grub.d/" 41_snapshots-btrfs
 	@install -Dm644 -t "$(DESTDIR)/etc/default/grub-btrfs/" config
 	@install -Dm755 -t "$(DESTDIR)/etc/init.d" grub-btrfs-rc
+        @install -Dm755 -t "$(DESTDIR)/usr/bin" grub-btrfsd
 	@install -Dm644 -t "$(SHARE_DIR)/licenses/$(PKGNAME)/" LICENSE
 	@# Arch Linux like distros only :
 	@if test "$(INITCPIO)" = true; then \

--- a/grub-btrfs-rc
+++ b/grub-btrfs-rc
@@ -1,10 +1,14 @@
 #!/sbin/openrc-run
 
-start() {
-    . /etc/default/grub-btrfs/config
-    if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then 
-        /etc/grub.d/41_snapshots-btrfs
-    else 
-        ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg
-    fi
+pidfile="/var/run/grub-btrfs-rc.pid"
+
+depend() {
+   use localmount
 }
+
+start() {
+    ebegin "Starting grub-btrfs daemon"
+    start-stop-daemon --background --start --exec /usr/bin/grub-btrfsd
+    eend $?
+}
+

--- a/grub-btrfsd
+++ b/grub-btrfsd
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+while true; do sleep 1 && inotifywait -e create /run/timeshift/backup/timeshift-btrfs/snapshots && sleep 5 &&  if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi  ; done
+
+
+


### PR DESCRIPTION
…ectory

Hi, 

I am using this pull request mainly to get in touch with you somehow. 
I saw your repo for this openrc version of this because I made a ebuild for grub-btrfs for gentoo guru and the dev of grub-btrfs showed me your repo. 
I made a working implementation of a openrc-service that monitors the snapshot directory of timeshift. I works like their systemd-service, I am not very happy with the implementation, though. I need to poll the directory every five seconds to start inotify when it becomes available. 

Anyways, let me know if you want to work together on this. Since this is basically just the service that is changed an the actual grub-btrfs is unchanged, are you going to merge your fork back into Antynea/grub-btrfs when its working?
